### PR TITLE
fix: inifite loop because page & base are undefined in parsePage

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
     Project List Page
     -->
 
-    <div data-role="page" id="project-list-page">
+    <div data-role="page" id="project-list-page" data-external-page="true">
 
       <div data-role="header">
         <a href="#" data-role="button" data-rel="back"
@@ -192,7 +192,7 @@
     -->
 
 
-    <div data-role="page" id="task-detail-page">
+    <div data-role="page" id="task-detail-page" data-external-page="true">
 
       <div data-role="header">
         <a href="#" data-role="button" data-rel="back"
@@ -330,7 +330,7 @@
     -->
 
 
-    <div data-role="page" id="settings-page">
+    <div data-role="page" id="settings-page" data-external-page="true">
       <div data-role="header">
         <a href="#" data-role="button" data-rel="back"
           data-icon="arrow-l" data-mini="true"
@@ -420,7 +420,7 @@
     -->
 
 
-    <div data-role="page" id="storage-list-page">
+    <div data-role="page" id="storage-list-page" data-external-page="true">
       <div data-role="header">
         <a href="#" data-role="button" data-rel="back"
           data-icon="arrow-l" data-mini="true"
@@ -501,7 +501,7 @@
     -->
 
 
-    <div data-role="page" id="storage-detail-page">
+    <div data-role="page" id="storage-detail-page" data-external-page="true">
       <div data-role="header">
         <a href="#" data-role="button" data-rel="back"
           data-icon="arrow-l" data-mini="true"

--- a/modules/taskman.js
+++ b/modules/taskman.js
@@ -907,7 +907,7 @@ $(document).on('mobileinit', function () {
       config = parseLink(raw_url);
 
       if (e) {
-        page = getPage(raw_url.split("#").pop());
+        page = document.getElementById(raw_url.split("#").pop());
         base = page ? page.getAttribute("data-external-page") : null;
         first = $.mobile.firstPage[0].getAttribute("data-url") === config.data_url;
 


### PR DESCRIPTION
This fixes the infinite loop, which was cause by `page` and `base` being undefined.

Explanation:  
The method was setup to look for a page by `data-url` (via getPage) to set `page` and for `data-external-page` to determine `base`. 

On **pagebeforechange** on the first loop through parsePage a non-existent page would cause both `page` and `data` to be undefined, hence this would be the place to generate the page and trigger a new changePage (to this page). 

On the following **pagebeforechange**, the page would have been appended to the DOM and either you (manually) or JQM would have set both `data-url` and `data-external-page`, so `page` and `base` are defined and JQM would finish the transition.

In your case, the pages are already in the DOM but missing both `data-url` and `data-external-page`, so you will loop into infinity.

The fix should be the same for both branches. When loading page externally, make sure JQM sets both attributes and that on the first test ("stop us, JQM go") `page` and `base` are defined.
